### PR TITLE
Add Voice-to-Text project with dynamic releases page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .cache/
 public
 static/releases/**/*.zip
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .cache/
 public
+static/releases/**/*.zip

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,19 @@
 import "./src/pages/global.css"
+
+// Override Gatsby's default scroll on navigation so the jump is instant,
+// not a smooth animation that briefly reveals the bottom of a shorter page
+// (because html { scroll-behavior: smooth } would otherwise animate it).
+export const shouldUpdateScroll = ({
+  routerProps: { location },
+  getSavedScrollPosition,
+}) => {
+  const savedPosition = getSavedScrollPosition(location) || [0, 0]
+  if (typeof window !== "undefined") {
+    window.scrollTo({
+      left: savedPosition[0],
+      top: savedPosition[1],
+      behavior: "instant",
+    })
+  }
+  return false
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -40,6 +40,13 @@ module.exports = {
         closedSource: true,
         tags: [".NET 10", "Blazor Server", "C#", "AI/LLMs", "Turso"],
       },
+      {
+        name: "Voice-to-Text",
+        description: "Local push-to-talk speech-to-text for Windows. Hold a hotkey, speak, release — transcribed text lands in your clipboard. 100% offline, powered by whisper.cpp.",
+        closedSource: true,
+        downloadsUrl: "/releases/voice-to-text",
+        tags: ["AutoHotkey", "C#", ".NET 10", "whisper.cpp"],
+      },
     ],
     tagUrls: [
       { name: "React", url: "https://react.dev" },
@@ -52,6 +59,8 @@ module.exports = {
       { name: "C#", url: "https://learn.microsoft.com/en-us/dotnet/csharp/" },
       { name: "AI/LLMs", url: "https://en.wikipedia.org/wiki/Large_language_model" },
       { name: "Turso", url: "https://turso.tech/" },
+      { name: "AutoHotkey", url: "https://www.autohotkey.com/" },
+      { name: "whisper.cpp", url: "https://github.com/ggerganov/whisper.cpp" },
     ],
   },
   plugins: [

--- a/src/components/ProjectCard/ProjectCard.css
+++ b/src/components/ProjectCard/ProjectCard.css
@@ -214,6 +214,17 @@
   box-shadow: inset 0 0 0 1px rgba(251, 191, 36, 0.5);
 }
 
+.project-link.download {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.project-link.download .download-icon {
+  width: 11px;
+  height: 11px;
+}
+
 @media (max-width: 500px) {
   .source-tooltip {
     right: auto;

--- a/src/components/ProjectCard/ProjectCard.jsx
+++ b/src/components/ProjectCard/ProjectCard.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { Link } from "gatsby"
 import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import "./ProjectCard.css"
 
@@ -11,6 +12,7 @@ export default function ProjectCard({ project, image, tagUrls }) {
     description,
     sourceUrl,
     liveUrl,
+    downloadsUrl,
     closedSource,
     tags,
   } = project
@@ -141,6 +143,29 @@ export default function ProjectCard({ project, image, tagUrls }) {
             >
               Visit
             </a>
+          )}
+          {downloadsUrl && (
+            <Link
+              to={downloadsUrl}
+              onClick={(e) => e.stopPropagation()}
+              className="project-link download"
+            >
+              <svg
+                className="download-icon"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 3v12" />
+                <path d="m7 10 5 5 5-5" />
+                <path d="M5 21h14" />
+              </svg>
+              Download
+            </Link>
           )}
           {imageData && (
             <button

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -466,7 +466,6 @@ export default function Home() {
     let cvButtonDocPos = null
 
     // Scroll state for fading button overlay
-    let isScrolling = false
     let scrollTimeout = null
     let buttonOpacity = 1.0
     let targetButtonOpacity = 1.0
@@ -947,7 +946,6 @@ export default function Home() {
     const handleScroll = () => {
       // Fade out button overlay while scrolling
       targetButtonOpacity = 0
-      isScrolling = true
 
       // Clear existing timeout
       if (scrollTimeout) {
@@ -956,7 +954,6 @@ export default function Home() {
 
       // Fade back in after scrolling stops
       scrollTimeout = setTimeout(() => {
-        isScrolling = false
         targetButtonOpacity = 1
       }, 300)
     }

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,6 +17,7 @@ export default function Home() {
             imageName
             sourceUrl
             liveUrl
+            downloadsUrl
             closedSource
             tags
           }

--- a/src/pages/releases/voice-to-text.css
+++ b/src/pages/releases/voice-to-text.css
@@ -197,6 +197,28 @@
   margin-bottom: 3rem;
 }
 
+.releases-fetch-notice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  padding: 0.85rem 1.1rem;
+  border-radius: 12px;
+  background: rgba(251, 146, 60, 0.08);
+  border: 1px solid rgba(251, 146, 60, 0.3);
+  color: rgba(251, 200, 150, 0.95);
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.releases-fetch-notice svg {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: rgba(251, 146, 60, 0.9);
+}
+
 .download-card {
   background: var(--bg-card, rgba(12, 14, 18, 0.92));
   backdrop-filter: blur(24px);

--- a/src/pages/releases/voice-to-text.css
+++ b/src/pages/releases/voice-to-text.css
@@ -1,0 +1,621 @@
+.releases-page {
+  position: relative;
+  z-index: 10;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem 1.5rem 4rem;
+  font-family: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--text-primary, #ffffff);
+}
+
+.releases-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.releases-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+  text-decoration: none;
+  padding: 0.5rem 0.9rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 212, 212, 0.15);
+  background: rgba(12, 14, 18, 0.6);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: all 0.2s ease;
+}
+
+.releases-back svg {
+  width: 14px;
+  height: 14px;
+}
+
+.releases-back:hover {
+  color: var(--accent, #00d4d4);
+  border-color: rgba(0, 212, 212, 0.4);
+  background: rgba(0, 212, 212, 0.08);
+}
+
+.releases-breadcrumb {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.8rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+}
+
+.releases-breadcrumb strong {
+  color: var(--accent, #00d4d4);
+  font-weight: 500;
+}
+
+/* HERO ------------------------------------------------------------------ */
+
+.releases-hero {
+  text-align: center;
+  padding: 0.5rem 1rem 1.5rem;
+  position: relative;
+}
+
+.releases-mic {
+  position: relative;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent, #00d4d4);
+}
+
+.mic-icon {
+  width: 32px;
+  height: 32px;
+  position: relative;
+  z-index: 3;
+  filter: drop-shadow(0 0 12px rgba(0, 212, 212, 0.6));
+}
+
+.mic-pulse {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 212, 212, 0.45);
+  animation: micPulse 2.4s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+.mic-pulse-1 { animation-delay: 0s; }
+.mic-pulse-2 { animation-delay: 0.8s; }
+.mic-pulse-3 { animation-delay: 1.6s; }
+
+@keyframes micPulse {
+  0% {
+    transform: scale(0.6);
+    opacity: 0.8;
+  }
+  100% {
+    transform: scale(1.8);
+    opacity: 0;
+  }
+}
+
+.releases-eyebrow {
+  display: inline-block;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent, #00d4d4);
+  background: rgba(0, 212, 212, 0.1);
+  border: 1px solid rgba(0, 212, 212, 0.25);
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  margin-bottom: 0.75rem;
+}
+
+.releases-title {
+  font-size: clamp(2.25rem, 6vw, 3.25rem);
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1.05;
+  margin: 0 0 0.75rem;
+  background: linear-gradient(135deg, #ffffff 0%, var(--accent, #00d4d4) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.releases-tagline {
+  max-width: 620px;
+  margin: 0 auto 1rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+  font-size: clamp(0.9rem, 1.8vw, 1rem);
+  line-height: 1.55;
+}
+
+.releases-tagline a {
+  color: var(--accent, #00d4d4);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(0, 212, 212, 0.35);
+  transition: border-color 0.2s ease;
+}
+
+.releases-tagline a:hover {
+  border-bottom-color: var(--accent, #00d4d4);
+}
+
+.releases-hotkey {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: 10px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s ease;
+}
+
+.releases-hotkey:hover {
+  background: rgba(0, 212, 212, 0.06);
+}
+
+.releases-hotkey .kbd {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.78rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 212, 212, 0.3);
+  background: rgba(0, 212, 212, 0.08);
+  box-shadow: 0 2px 0 rgba(0, 212, 212, 0.15);
+  color: var(--text-primary, #ffffff);
+}
+
+.releases-hotkey .plus {
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+  font-size: 0.85rem;
+}
+
+.releases-hotkey .hotkey-hint {
+  margin-left: 0.5rem;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.7rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* DOWNLOAD CARD --------------------------------------------------------- */
+
+.releases-download {
+  margin-bottom: 3rem;
+}
+
+.download-card {
+  background: var(--bg-card, rgba(12, 14, 18, 0.92));
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border-radius: 18px;
+  border: 1px solid rgba(0, 212, 212, 0.15);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.4),
+              0 0 40px rgba(0, 212, 212, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.download-card::before,
+.download-card::after {
+  content: '';
+  position: absolute;
+  width: 22px;
+  height: 22px;
+  border: 2px solid var(--accent, #00d4d4);
+  opacity: 0.3;
+}
+
+.download-card::before {
+  top: 14px;
+  left: 14px;
+  border-right: none;
+  border-bottom: none;
+}
+
+.download-card::after {
+  bottom: 14px;
+  right: 14px;
+  border-left: none;
+  border-top: none;
+}
+
+.download-card .glow-line {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--accent, #00d4d4) 20%,
+    var(--accent, #00d4d4) 80%,
+    transparent 100%
+  );
+  opacity: 0.5;
+}
+
+.download-card-body {
+  padding: 1.75rem 2rem;
+  text-align: center;
+}
+
+.download-meta {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.version-badge {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--accent, #00d4d4);
+  background: rgba(0, 212, 212, 0.12);
+  border: 1px solid rgba(0, 212, 212, 0.35);
+  padding: 0.25rem 0.6rem;
+  border-radius: 5px;
+  letter-spacing: 0.05em;
+}
+
+.download-date {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+}
+
+.download-heading {
+  font-size: 1.5rem;
+  font-weight: 500;
+  margin: 0 0 0.4rem;
+  letter-spacing: -0.01em;
+}
+
+.download-sub {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.82rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+  margin: 0 0 1.25rem;
+}
+
+.download-size {
+  color: var(--accent, #00d4d4);
+}
+
+.download-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #0a0a0f;
+  text-decoration: none;
+  padding: 1rem 2rem;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #00d4d4 0%, #00a8a8 100%);
+  box-shadow: 0 8px 30px rgba(0, 212, 212, 0.35),
+              inset 0 1px 0 rgba(255, 255, 255, 0.2);
+  transition: all 0.25s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.download-btn::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, transparent 0%, rgba(255, 255, 255, 0.15) 50%, transparent 100%);
+  transform: translateX(-100%);
+  transition: transform 0.6s ease;
+}
+
+.download-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px rgba(0, 212, 212, 0.5),
+              inset 0 1px 0 rgba(255, 255, 255, 0.25);
+}
+
+.download-btn:hover::before {
+  transform: translateX(100%);
+}
+
+.download-btn svg {
+  width: 18px;
+  height: 18px;
+  position: relative;
+  z-index: 1;
+}
+
+.download-disclaimer {
+  margin: 1.5rem auto 0;
+  max-width: 480px;
+  font-size: 0.78rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+  line-height: 1.55;
+}
+
+/* SECTIONS -------------------------------------------------------------- */
+
+.releases-section {
+  margin-bottom: 3rem;
+}
+
+.section-title {
+  font-size: 1.15rem;
+  font-weight: 500;
+  margin: 0 0 1.25rem;
+  padding-bottom: 0.5rem;
+  letter-spacing: -0.005em;
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.section-title::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--accent, #00d4d4), transparent);
+}
+
+/* Features grid */
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.9rem;
+}
+
+.feature-card {
+  background: rgba(0, 212, 212, 0.03);
+  border: 1px solid rgba(0, 212, 212, 0.12);
+  border-radius: 12px;
+  padding: 1.25rem 1.2rem;
+  transition: all 0.25s ease;
+  position: relative;
+}
+
+.feature-card:hover {
+  border-color: rgba(0, 212, 212, 0.3);
+  background: rgba(0, 212, 212, 0.05);
+  transform: translateY(-2px);
+}
+
+.feature-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent, #00d4d4);
+  box-shadow: 0 0 10px var(--accent, #00d4d4);
+  margin-bottom: 0.75rem;
+}
+
+.feature-card h3 {
+  font-size: 0.95rem;
+  font-weight: 500;
+  margin: 0 0 0.4rem;
+}
+
+.feature-card p {
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* Requirements */
+
+.requirements-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.requirements-list li {
+  position: relative;
+  padding: 0.7rem 0.9rem 0.7rem 2.2rem;
+  background: rgba(0, 212, 212, 0.03);
+  border: 1px solid rgba(0, 212, 212, 0.1);
+  border-radius: 8px;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+}
+
+.requirements-list li::before {
+  content: '✓';
+  position: absolute;
+  left: 0.85rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--accent, #00d4d4);
+  font-weight: 600;
+}
+
+/* Install steps */
+
+.install-steps {
+  list-style: none;
+  counter-reset: step;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.install-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 0.9rem 1rem;
+  background: rgba(12, 14, 18, 0.5);
+  border: 1px solid rgba(0, 212, 212, 0.1);
+  border-radius: 10px;
+  transition: all 0.2s ease;
+}
+
+.install-steps li:hover {
+  border-color: rgba(0, 212, 212, 0.25);
+}
+
+.install-step-num {
+  flex-shrink: 0;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--accent, #00d4d4);
+  background: rgba(0, 212, 212, 0.1);
+  border: 1px solid rgba(0, 212, 212, 0.25);
+  padding: 0.2rem 0.5rem;
+  border-radius: 5px;
+  letter-spacing: 0.05em;
+  margin-top: 0.05rem;
+}
+
+.install-step-body {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.85));
+}
+
+/* Release notes */
+
+.release-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.release-entry {
+  background: rgba(12, 14, 18, 0.5);
+  border: 1px solid rgba(0, 212, 212, 0.12);
+  border-radius: 12px;
+  padding: 1.25rem 1.25rem;
+}
+
+.release-entry-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.9rem;
+  padding-bottom: 0.9rem;
+  border-bottom: 1px dashed rgba(0, 212, 212, 0.15);
+}
+
+.release-entry-date {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+}
+
+.release-entry-download {
+  margin-left: auto;
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.75rem;
+  color: var(--accent, #00d4d4);
+  text-decoration: none;
+  padding: 0.3rem 0.6rem;
+  border-radius: 5px;
+  border: 1px solid rgba(0, 212, 212, 0.25);
+  transition: all 0.2s ease;
+}
+
+.release-entry-download:hover {
+  background: rgba(0, 212, 212, 0.1);
+  border-color: rgba(0, 212, 212, 0.5);
+}
+
+.release-entry ul {
+  margin: 0;
+  padding: 0 0 0 1.2rem;
+  color: var(--text-secondary, rgba(255, 255, 255, 0.75));
+  font-size: 0.88rem;
+  line-height: 1.7;
+}
+
+.release-entry ul li::marker {
+  color: var(--accent, #00d4d4);
+}
+
+/* Footer */
+
+.releases-footer {
+  margin-top: 3rem;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(0, 212, 212, 0.1);
+  text-align: center;
+}
+
+.releases-footer-link {
+  font-family: 'Geist Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--text-muted, rgba(255, 255, 255, 0.5));
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.releases-footer-link:hover {
+  color: var(--accent, #00d4d4);
+}
+
+/* Responsive ------------------------------------------------------------ */
+
+@media (max-width: 600px) {
+  .releases-page {
+    padding: 1.25rem 1rem 3rem;
+  }
+
+  .releases-nav {
+    margin-bottom: 2rem;
+  }
+
+  .releases-hero {
+    padding: 1rem 0.25rem 2rem;
+  }
+
+  .download-card-body {
+    padding: 2rem 1.25rem;
+  }
+
+  .download-btn {
+    padding: 0.9rem 1.5rem;
+    font-size: 0.88rem;
+  }
+
+  .release-entry-header {
+    gap: 0.5rem;
+  }
+
+  .release-entry-download {
+    margin-left: 0;
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/pages/releases/voice-to-text.js
+++ b/src/pages/releases/voice-to-text.js
@@ -79,13 +79,18 @@ function parseReleaseNotes(body) {
 export default function VoiceToTextReleases() {
   const [copied, setCopied] = useState(false)
   const [releases, setReleases] = useState(fallbackReleases)
+  const [fetchFailed, setFetchFailed] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     fetch(`https://api.github.com/repos/${REPO}/releases`)
       .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
       .then((data) => {
-        if (cancelled || !Array.isArray(data) || data.length === 0) return
+        if (cancelled) return
+        if (!Array.isArray(data) || data.length === 0) {
+          setFetchFailed(true)
+          return
+        }
         const mapped = data
           .filter((r) => !r.draft)
           .map((r) => {
@@ -99,10 +104,14 @@ export default function VoiceToTextReleases() {
               notes: parseReleaseNotes(r.body),
             }
           })
-        if (mapped.length > 0) setReleases(mapped)
+        if (mapped.length > 0) {
+          setReleases(mapped)
+        } else {
+          setFetchFailed(true)
+        }
       })
       .catch(() => {
-        // keep fallback
+        if (!cancelled) setFetchFailed(true)
       })
     return () => {
       cancelled = true
@@ -198,6 +207,27 @@ export default function VoiceToTextReleases() {
         </header>
 
         <section className="releases-download">
+          {fetchFailed && (
+            <div className="releases-fetch-notice" role="status">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <line x1="12" y1="8" x2="12" y2="13" />
+                <line x1="12" y1="16" x2="12.01" y2="16" />
+              </svg>
+              <span>
+                Couldn&apos;t fetch live release metadata from GitHub. Showing cached info —
+                the download button still resolves to the latest release.
+              </span>
+            </div>
+          )}
           <div className="download-card">
             <div className="glow-line" />
             <div className="download-card-body">

--- a/src/pages/releases/voice-to-text.js
+++ b/src/pages/releases/voice-to-text.js
@@ -1,0 +1,310 @@
+import React, { useEffect, useState } from "react"
+import { Helmet } from "react-helmet"
+import { Link } from "gatsby"
+
+import { FluidBackground } from "../../components"
+import "./voice-to-text.css"
+
+const REPO = "jreverett/voice-to-text"
+const ASSET_NAME = "voice-to-text.zip"
+const DOWNLOAD_URL = `https://github.com/${REPO}/releases/latest/download/${ASSET_NAME}`
+
+const fallbackReleases = [
+  {
+    version: "v1.0.0",
+    date: "2026-04-22",
+    sizeBytes: 47323953,
+    notes: [
+      "Initial public release.",
+      "Standalone Windows bundle — no installer, no dependencies to fetch.",
+      "Push-to-talk speech-to-text with whisper.cpp (small.en model).",
+      "WASAPI microphone capture via bundled mic-capture tool.",
+      "Tray icon with idle / starting / recording / transcribing states.",
+      "Configurable hotkey, model, threads, and audio device via config.ini.",
+    ],
+  },
+]
+
+const features = [
+  {
+    title: "100% local",
+    body: "Audio and transcripts never leave your machine. No cloud, no API keys, no usage limits.",
+  },
+  {
+    title: "Push-to-talk",
+    body: "Hold Shift+Alt (or any hotkey you like), speak, release. Text lands in your clipboard.",
+  },
+  {
+    title: "Fast on CPU",
+    body: "~1.5–3s turnaround on a modern CPU with the small.en model. Tune threads and model to taste.",
+  },
+  {
+    title: "Tray-native UX",
+    body: "Coloured tray icon shows state at a glance: idle, starting, recording, transcribing.",
+  },
+]
+
+const requirements = [
+  "Windows 10 or later (x64)",
+  "~150 MB free disk space (extracted)",
+  "A microphone (any WASAPI capture device)",
+]
+
+const installSteps = [
+  "Download the zip and extract it into a folder you own (e.g. C:\\Tools\\voice-to-text\\).",
+  "(Optional) open config.ini and set your preferred hotkey or microphone.",
+  "Double-click voice-to-text.exe. It will auto-elevate for global hotkey support.",
+  "Hold Shift+Alt, speak, release — then paste anywhere with Ctrl+V.",
+]
+
+function formatSize(bytes) {
+  if (!bytes && bytes !== 0) return ""
+  const mb = bytes / (1024 * 1024)
+  return `${mb.toFixed(1)} MB`
+}
+
+function formatDate(iso) {
+  if (!iso) return ""
+  return iso.slice(0, 10)
+}
+
+function parseReleaseNotes(body) {
+  if (!body) return []
+  return body
+    .split("\n")
+    .map((line) => line.replace(/^[-*]\s+/, "").trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+}
+
+export default function VoiceToTextReleases() {
+  const [copied, setCopied] = useState(false)
+  const [releases, setReleases] = useState(fallbackReleases)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`https://api.github.com/repos/${REPO}/releases`)
+      .then((r) => (r.ok ? r.json() : Promise.reject(r.status)))
+      .then((data) => {
+        if (cancelled || !Array.isArray(data) || data.length === 0) return
+        const mapped = data
+          .filter((r) => !r.draft)
+          .map((r) => {
+            const asset =
+              (r.assets || []).find((a) => a.name === ASSET_NAME) ||
+              (r.assets || [])[0]
+            return {
+              version: r.tag_name || r.name,
+              date: formatDate(r.published_at || r.created_at),
+              sizeBytes: asset ? asset.size : null,
+              notes: parseReleaseNotes(r.body),
+            }
+          })
+        if (mapped.length > 0) setReleases(mapped)
+      })
+      .catch(() => {
+        // keep fallback
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const latest = releases[0]
+
+  const handleCopyHotkey = () => {
+    if (typeof navigator === "undefined" || !navigator.clipboard) return
+    navigator.clipboard.writeText("Shift+Alt").then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>Voice-to-Text — Downloads | Jamie Everett</title>
+        <meta
+          name="description"
+          content="Download Voice-to-Text: a local, offline push-to-talk speech-to-text app for Windows, powered by whisper.cpp."
+        />
+      </Helmet>
+      <FluidBackground />
+
+      <div className="releases-page">
+        <nav className="releases-nav">
+          <Link to="/" className="releases-back" data-splash="link">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="m15 18-6-6 6-6" />
+            </svg>
+            Back to portfolio
+          </Link>
+          <span className="releases-breadcrumb">
+            releases / <strong>voice-to-text</strong>
+          </span>
+        </nav>
+
+        <header className="releases-hero">
+          <div className="releases-mic" aria-hidden="true">
+            <div className="mic-pulse mic-pulse-1" />
+            <div className="mic-pulse mic-pulse-2" />
+            <div className="mic-pulse mic-pulse-3" />
+            <svg
+              className="mic-icon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="2" width="6" height="12" rx="3" />
+              <path d="M5 10v2a7 7 0 0 0 14 0v-2" />
+              <path d="M12 19v3" />
+            </svg>
+          </div>
+
+          <span className="releases-eyebrow">Windows · offline · free</span>
+          <h1 className="releases-title">Voice-to-Text</h1>
+          <p className="releases-tagline">
+            Local push-to-talk speech-to-text. Hold a hotkey, speak, release —
+            transcribed text lands in your clipboard. Powered by{" "}
+            <a
+              href="https://github.com/ggerganov/whisper.cpp"
+              target="_blank"
+              rel="noreferrer"
+              data-splash="link"
+            >
+              whisper.cpp
+            </a>
+            .
+          </p>
+
+          <div className="releases-hotkey" onClick={handleCopyHotkey} role="button" tabIndex={0}
+            onKeyDown={(e) => (e.key === "Enter" || e.key === " ") && handleCopyHotkey()}
+            aria-label="Copy default hotkey">
+            <span className="kbd">Shift</span>
+            <span className="plus">+</span>
+            <span className="kbd">Alt</span>
+            <span className="hotkey-hint">{copied ? "copied" : "default hotkey"}</span>
+          </div>
+        </header>
+
+        <section className="releases-download">
+          <div className="download-card">
+            <div className="glow-line" />
+            <div className="download-card-body">
+              <div className="download-meta">
+                <span className="version-badge">{latest.version}</span>
+                <span className="download-date">Released {latest.date}</span>
+              </div>
+              <h2 className="download-heading">Latest release</h2>
+              <p className="download-sub">
+                Windows bundle · <span className="download-size">{formatSize(latest.sizeBytes)}</span>
+              </p>
+
+              <a
+                href={DOWNLOAD_URL}
+                className="download-btn"
+                data-splash="link"
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <path d="M12 3v12" />
+                  <path d="m7 10 5 5 5-5" />
+                  <path d="M5 21h14" />
+                </svg>
+                Download {latest.version}
+              </a>
+
+              <p className="download-disclaimer">
+                By downloading you agree this is an unsigned Windows build. Your browser or
+                SmartScreen may warn you — that&apos;s expected for open-tool binaries.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="releases-section">
+          <h2 className="section-title">What&apos;s inside</h2>
+          <div className="feature-grid">
+            {features.map((feature) => (
+              <div className="feature-card" key={feature.title}>
+                <div className="feature-card-dot" />
+                <h3>{feature.title}</h3>
+                <p>{feature.body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="releases-section">
+          <h2 className="section-title">Requirements</h2>
+          <ul className="requirements-list">
+            {requirements.map((req) => (
+              <li key={req}>{req}</li>
+            ))}
+          </ul>
+        </section>
+
+        <section className="releases-section">
+          <h2 className="section-title">Install</h2>
+          <ol className="install-steps">
+            {installSteps.map((step, i) => (
+              <li key={i}>
+                <span className="install-step-num">{String(i + 1).padStart(2, "0")}</span>
+                <span className="install-step-body">{step}</span>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        <section className="releases-section">
+          <h2 className="section-title">Release notes</h2>
+          <div className="release-list">
+            {releases.map((release) => (
+              <div className="release-entry" key={release.version}>
+                <div className="release-entry-header">
+                  <span className="version-badge">{release.version}</span>
+                  <span className="release-entry-date">{release.date}</span>
+                  <a
+                    className="release-entry-download"
+                    href={`https://github.com/${REPO}/releases/download/${release.version}/${ASSET_NAME}`}
+                    data-splash="link"
+                  >
+                    {ASSET_NAME} ({formatSize(release.sizeBytes)})
+                  </a>
+                </div>
+                <ul>
+                  {release.notes.map((note, i) => (
+                    <li key={i}>{note}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <footer className="releases-footer">
+          <Link to="/" className="releases-footer-link" data-splash="link">
+            ← Back to portfolio
+          </Link>
+        </footer>
+      </div>
+    </>
+  )
+}

--- a/src/pages/releases/voice-to-text.js
+++ b/src/pages/releases/voice-to-text.js
@@ -92,7 +92,7 @@ export default function VoiceToTextReleases() {
           return
         }
         const mapped = data
-          .filter((r) => !r.draft)
+          .filter((r) => !r.draft && !r.prerelease)
           .map((r) => {
             const asset =
               (r.assets || []).find((a) => a.name === ASSET_NAME) ||


### PR DESCRIPTION
## Summary
- Adds the Voice-to-Text project card to the portfolio and a dedicated releases page at `/releases/voice-to-text`
- Download link resolves to the latest GitHub Release asset (`github.com/jreverett/voice-to-text/releases/latest/download/voice-to-text.zip`) — no website rebuild needed when a new release ships
- Releases page fetches the GitHub Releases API client-side to render version, date and notes for every release; hardcoded v1.0.0 fixture as SSR fallback

## Notes
- No binaries committed — release artifacts live on GitHub Releases (managed by release-please in the `voice-to-text` repo)
- `static/releases/**/*.zip` added to `.gitignore` defensively